### PR TITLE
Fix build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/raksoq/iwebpack#readme",
   "dependencies": {
-    "itoolkit": "^0.1.6"
+    "itoolkit": "^0.1.6",
+    "idb-connector": "^1.1.10"
   },
   "devDependencies": {
     "webpack": "^4.31.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,23 @@
-var path = require('path');
+const path = require('path');
+const fs = require('fs');
+
+let nodeModules = {};
+
+fs.readdirSync('node_modules')
+  .filter((x) => {
+    return ['.bin'].indexOf(x) === -1;
+  })
+  .forEach((mod) => {
+    nodeModules[mod] = `commonjs ${mod}`;
+  });
 
 module.exports = {
+  target: 'node',
   mode: 'production',
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'main.js'
-  }
+  },
+   externals: nodeModules
 };


### PR DESCRIPTION
After doing some research I found a really useful [article](https://jlongster.com/Backend-Apps-with-Webpack--Part-I) that helped solve the build issues.

```bash
npm install; npm run build; npm run start
```


```
> webpack

Hash: d3989597558eccc50b45
Version: webpack 4.31.0
Time: 1196ms
Built at: 05/17/2019 12:28:20 PM
  Asset      Size  Chunks             Chunk Names
main.js  1.15 KiB       0  [emitted]  main
Entrypoint main = main.js
[0] ./src/index.js 718 bytes {0} [built]
[1] external "itoolkit" 42 bytes {0} [built]
```